### PR TITLE
Improved Flatpak compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .cache/
+.vscode/
 wemod_bin/
 wemod_data/
 wemod_venv/

--- a/mainutils.py
+++ b/mainutils.py
@@ -652,8 +652,8 @@ def flatpakrunner():
         print(str(process.stderr))
     try:
         if os.getenv("SteamCompatDataPath") == None:
-            wserver = subprocess.run(["flatpak-spawn", "--host"]+
-                ["wineserver", "--wait"],
+            wserver = subprocess.run(
+                ["flatpak-spawn", "--host","wineserver", "--wait"],
                 bufsize=1,
                 capture_output=True,
                 text=True,

--- a/mainutils.py
+++ b/mainutils.py
@@ -609,6 +609,9 @@ def unpack_zip_with_progress(zip_path: str, dest_path: str) -> None:
     window.close()
 
 
+def is_flatpak() -> bool:
+    return "FLATPAK_ID" in os.environ or os.path.exists("/.flatpak-info")
+
 def flatpakrunner():
     import subprocess
     import time
@@ -649,7 +652,7 @@ def flatpakrunner():
         print(str(process.stderr))
     try:
         if os.getenv("SteamCompatDataPath") == None:
-            wserver = subprocess.run(
+            wserver = subprocess.run(["flatpak-spawn", "--host"]+
                 ["wineserver", "--wait"],
                 bufsize=1,
                 capture_output=True,

--- a/setup.py
+++ b/setup.py
@@ -270,8 +270,10 @@ def self_update(path: List[Optional[str]]) -> List[Optional[str]]:
         os.chdir(SCRIPT_PATH)
 
         # Check if we're in the main branch
-        curr_branch = subprocess.run(flatpak_cmd +
-            ["git", "branch", "--show-current"], stdout=subprocess.PIPE, text=True
+        curr_branch = subprocess.run(
+            flatpak_cmd + ["git", "branch", "--show-current"],
+            stdout=subprocess.PIPE,
+            text=True
         ).stdout.strip()
         if curr_branch != "main":
             log("Currently not in main branch. Aborting update")
@@ -283,14 +285,18 @@ def self_update(path: List[Optional[str]]) -> List[Optional[str]]:
         subprocess.run(flatpak_cmd + ["git", "fetch"], text=True)
 
         # Get local and remote commit hashes
-        local_hash = subprocess.run(flatpak_cmd +
-            ["git", "rev-parse", "@"], stdout=subprocess.PIPE, text=True
+        local_hash = subprocess.run(
+            flatpak_cmd + ["git", "rev-parse", "@"],
+            stdout=subprocess.PIPE,
+            text=True
         ).stdout.strip()
-        remote_hash = subprocess.run(flatpak_cmd +
-            ["git", "rev-parse", "@{u}"], stdout=subprocess.PIPE, text=True
+        remote_hash = subprocess.run(
+            flatpak_cmd + ["git", "rev-parse", "@{u}"],
+            stdout=subprocess.PIPE,
+            text=True
         ).stdout.strip()
-        base_hash = subprocess.run(flatpak_cmd +
-            ["git", "merge-base", "@", "@{u}"],
+        base_hash = subprocess.run(
+            flatpak_cmd + ["git", "merge-base", "@", "@{u}"],
             stdout=subprocess.PIPE,
             text=True,
         ).stdout.strip()

--- a/wemod
+++ b/wemod
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     if_flatpak_list = check_flatpak(python_venv)
 
     # On venv path restart the script
-    if bool(if_flatpak_list):
+    if 0 < len(if_flatpak_list):
         # Use environment variable to protect the script from re-running forever
         inf_protect = os.getenv("WeModInfProtect", "1")
         if int(inf_protect) > 4:
@@ -749,6 +749,8 @@ def run(skip_init: bool = False) -> str:
     if fromflat:
         import time
 
+        resp = 0
+
         log("Using flatpak mode")
 
         cachedir = os.path.join(SCRIPT_PATH, ".cache")
@@ -782,6 +784,7 @@ def run(skip_init: bool = False) -> str:
                 error = fef.read()
                 os.remove(errorfile)
                 if error:
+                    resp = 1
                     raise Exception(str(error))
 
         log("Any warnings from the command the logged")


### PR DESCRIPTION
Overall changes:
- Making subprocess calls from within flatpak sandbox use `flatpak-spawn --host` for commands like `git` or `chmod`.
- Avoided resetting git branch if script finds it's not in main (I don't want to lose all that work again lol).
- `chmod`ing with executable flag only the appropriate files. This command might not even be necessary at all.
- Fixed random crash on exit.