### PR TITLE
docs: add goal, base guidelines, and base implemetation

### DIFF
--- a/docs/base-guidelines.md
+++ b/docs/base-guidelines.md
@@ -1,0 +1,136 @@
+# Docs: Wand Launcher flow draft
+
+> All paths in this doc use their default locations.  
+> If the corresponding XDG environment variable is set (`XDG_DATA_HOME`, `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`),  
+> the paths resolve accordingly.
+
+## The Main Flow
+
+The main flow is simple — the launcher is essentially a fancy argument parser. Here's what happens:
+
+### Bootstrap
+
+- Run root checks and resolve any pending updates
+- Migration manager checks the schema version in `~/.local/share/wand/metadata.json` and runs pending migrations if needed
+- Initialize the **SettingsManager** — a unified interface over CLI args, environment variables, config files, and XDG paths. Everything reads settings from here.
+- Detect the user interface — PyQt6 by default, CLI if `--cli` or `--no-prompt` flags are set
+- Enter the main execution block
+
+### Argument Parsing
+
+- The ArgManager (part of SettingsManager) wraps `sys.argv` once
+- Analyze the arguments for wine/proton to find the target game
+
+### Download the App
+
+- Download and extract the app exe if missing
+- See [Download the App](#download-the-app) for details
+
+### Prefix Setup
+
+- Make sure the prefix is set up (most complex task, irrelevant after the wand prefix is installed)
+- See [Prefix Setup](#prefix-setup) for details
+
+### Syncing App Data
+
+- Link app data to the shared storage after prefix is ready
+- See [Syncing App Data](#syncing-app-data) for details
+
+### Monitor Launch
+
+> The monitor process will live in a separate repository — it's a standalone
+> binary that communicates via TCP/JSON. The launcher only needs to launch it
+> and read its exit code.
+
+- Replace the command to run the monitor instead of the game
+- Pass the game exe path to the monitor via IPC as JSON
+- Run the monitor with the wine tool (proton in steam) which receives the game args
+- The monitor starts both the game and wand, then exits
+- See [The Monitor Start File](#the-monitor-start-file) for details
+
+### Troubleshooter
+
+- Bring up a simple troubleshooter if wand didn't start
+- All logs go to `~/.cache/wand/` (log level can be increased for debugging)
+- Offers options like redownloading the prefix, redownloading wand, or deleting the prefix to start fresh
+- By default this is a PyQt6 GUI with progress bars, buttons, and dialogs
+- With `--cli` it falls back to text-based prompts and line-overwrite progress
+- After the troubleshooter exits, the wand-launcher script exits
+
+---
+
+## Download the App
+
+To use wand the app exe needs to be in place. Downloads and temporary caches go to `~/.cache/wand/`.
+
+### Installing the App
+
+- Check if the app exe exists
+- If not, run the setup — downloads and extracts the app to `~/.local/share/wand/bin/` so all prefixes can use it
+- The exe contains all app files (dependencies are handled separately during prefix setup)
+
+---
+
+## Prefix Setup
+
+Once the app is downloaded, wand needs to be set up in the wine prefix. Config files live in `~/.config/wand/`, and updates and persistent storage use `~/.local/share/wand/`. This is the most complex part:
+
+### Checking the Prefix
+
+- Normalize prefix: move files from `pfx/` to `.` and delete `pfx`
+- Normalize user: move from `drive_c/users/steamuser/` to `drive_c/users/$USER/` and delete `steamuser`
+- Add symlinks: `pfx` → `.`, and in folder `drive_c/users/`; `steamuser` → `$USER`
+
+- Check if the prefix already has wand installed
+- Look for `.wand_installer` in the same folder as `drive_c`
+- If found: prefix install is done — return to [The Main Flow](#the-main-flow)
+
+### Scanning for Existing Prefixes
+
+If `.wand_installer` is missing, scan the parent directory for a sibling prefix that has it:
+
+1. Scan all sibling prefixes for `.wand_installer`, store results in `~/.local/share/wand/prefixes.json` and remove stale entries
+2. Look up the best matching prefix in the database
+
+Ask the user what to do (three options depend on how many valid prefixes exist):
+
+- **Closest match** — copy the best matching prefix (only if one or more valid prefixes exist)
+- **Download** — grab a wand-ready prefix from GitHub, unpack it (cached in `~/.cache/wand/`)
+- **Second Closest Match** — auto-pick the next best prefix (only if exactly 2 valid prefixes exist)
+- **List all** — pick from all valid prefixes (only if 3+ valid prefixes exist)
+- **Build** - Download winetricks, run `winetricks -q sdl cjkfonts vkd3d dxvk2030 dotnet48` and add `.wand_installer` next to `system.reg`
+- **Exit** — cancel
+
+Return to [The Main Flow](#the-main-flow) after completion.
+
+---
+
+## Syncing App Data
+
+After the prefix is set up, the app data needs to be linked to the shared storage at `~/.local/share/wand/`.
+
+- Copy the app data folder to `~/.local/share/wand/login/`
+- If it doesn't exist, create an empty folder there
+- Symlink the app's data folder inside the prefix to that central `login` folder
+- Now all games share the same app data — synced by design
+
+### Packaging a Prefix
+
+- Check if the prefix should be packaged into a zip
+- Used when a prefix needs to be uploaded
+
+---
+
+## The Monitor Start File
+
+The monitor is minimal — its job is process management inside the Wine/Proton environment:
+
+- Receive a `LaunchConfig` via TCP from the launcher
+- The config defines which processes to start, in what order, and dependency rules
+- Connect to the launcher on the given port
+- Start wand.exe (or another app defined in the config)
+- Start the game executable and wait
+- On game exit, send a `session_complete` event to the launcher
+- The launcher cleans up and the monitor exits
+
+This replaces the old bat file approach. Instead of a hardcoded batch script, the monitor uses a config-driven system where the launcher sends a structured `LaunchConfig` via JSON over TCP. This means the monitor is not limited to wand — it can manage any set of processes with proper lifecycle handling, dependencies, and startup order.

--- a/docs/base-guidelines.md
+++ b/docs/base-guidelines.md
@@ -10,16 +10,14 @@ The main flow is simple — the launcher is essentially a fancy argument parser.
 
 ### Bootstrap
 
-- Run root checks and resolve any pending updates
-- Migration manager checks the schema version in `~/.local/share/wand/metadata.json` and runs pending migrations if needed
-- Initialize the **SettingsManager** — a unified interface over CLI args, environment variables, game config, global config, and XDG paths. Merge priority: CLI args > env vars > game config (`games.json`, game paths as IDs) > global config (`config.json`) > hardcoded defaults. Everything reads settings from here.
-- Detect the user interface — PyQt6 by default, CLI if `--cli` or `--no-prompt` flags are set
+- **SettingsManager** — basic init: parses `sys.argv` and computes XDG paths. No config files loaded yet.
+- **LogManager** — takes settings (reads log path from it), starts the log file.
+- **Interface** — detected from settings flags: PyQt6 by default, CLI if `--cli` or `--no-prompt`.
+- **Root guard** — checks `os.geteuid()` and `--force-root`, exits early if running as root without the flag.
+- **SettingsManager.load_all()** — loads global config (`config.json`), game config (`games.json`), and metadata. Merge priority: CLI args > env vars > game config > global config > hardcoded defaults.
 - Enter the main execution block
 
-### Argument Parsing
-
-- The ArgManager wraps `sys.argv` once (separate from SettingsManager, which consumes it later)
-- Analyze the arguments for wine/proton to find the target game
+Arg parsing and path computation are handled by SettingsManager internally — no separate ArgManager or PathManager modules. Settings is the single source for flags, paths, and config values throughout the launcher.
 
 ### Download the App
 

--- a/docs/base-guidelines.md
+++ b/docs/base-guidelines.md
@@ -12,13 +12,13 @@ The main flow is simple — the launcher is essentially a fancy argument parser.
 
 - Run root checks and resolve any pending updates
 - Migration manager checks the schema version in `~/.local/share/wand/metadata.json` and runs pending migrations if needed
-- Initialize the **SettingsManager** — a unified interface over CLI args, environment variables, config files, and XDG paths. Everything reads settings from here.
+- Initialize the **SettingsManager** — a unified interface over CLI args, environment variables, game config, global config, and XDG paths. Merge priority: CLI args > env vars > game config (`games.json`, game paths as IDs) > global config (`config.json`) > hardcoded defaults. Everything reads settings from here.
 - Detect the user interface — PyQt6 by default, CLI if `--cli` or `--no-prompt` flags are set
 - Enter the main execution block
 
 ### Argument Parsing
 
-- The ArgManager (part of SettingsManager) wraps `sys.argv` once
+- The ArgManager wraps `sys.argv` once (separate from SettingsManager, which consumes it later)
 - Analyze the arguments for wine/proton to find the target game
 
 ### Download the App
@@ -38,14 +38,15 @@ The main flow is simple — the launcher is essentially a fancy argument parser.
 
 ### Monitor Launch
 
-> The monitor process will live in a separate repository — it's a standalone
-> binary that communicates via TCP/JSON. The launcher only needs to launch it
-> and read its exit code.
+> The monitor is a separate binary in its own repository — this section covers
+> the launcher side only. The launcher downloads `monitor.exe` from the
+> monitor's GitHub releases, sends a `LaunchConfig` via TCP/JSON, and reads
+> the exit code.
 
-- Replace the command to run the monitor instead of the game
-- Pass the game exe path to the monitor via IPC as JSON
-- Run the monitor with the wine tool (proton in steam) which receives the game args
-- The monitor starts both the game and wand, then exits
+- Download `monitor.exe` from the monitor's GitHub releases
+- Send a `LaunchConfig` via TCP/JSON with the game exe path, wand exe path, and lifecycle instructions
+- Wait for the monitor to report `session_complete` with the game's exit code
+- Return that exit code as the launcher's own exit code
 - See [The Monitor Start File](#the-monitor-start-file) for details
 
 ### Troubleshooter
@@ -66,7 +67,9 @@ To use wand the app exe needs to be in place. Downloads and temporary caches go 
 ### Installing the App
 
 - Check if the app exe exists
-- If not, run the setup — downloads and extracts the app to `~/.local/share/wand/bin/` so all prefixes can use it
+- If not, download the archive from the URL in `metadata.json`
+- Verify the downloaded archive against its reported checksum (provided by the online repo)
+- Extract to `~/.cache/wand/` then copy the app to `~/.local/share/wand/bin/` so all prefixes can use it
 - The exe contains all app files (dependencies are handled separately during prefix setup)
 
 ---
@@ -110,7 +113,7 @@ Return to [The Main Flow](#the-main-flow) after completion.
 After the prefix is set up, the app data needs to be linked to the shared storage at `~/.local/share/wand/`.
 
 - Copy the app data folder to `~/.local/share/wand/login/`
-- If it doesn't exist, create an empty folder there
+- If the shared store already has data and the prefix also has data, prompt the user to pick which copy wins
 - Symlink the app's data folder inside the prefix to that central `login` folder
 - Now all games share the same app data — synced by design
 
@@ -123,14 +126,11 @@ After the prefix is set up, the app data needs to be linked to the shared storag
 
 ## The Monitor Start File
 
-The monitor is minimal — its job is process management inside the Wine/Proton environment:
+The monitor is a separate binary (different repo). From the launcher's perspective:
 
-- Receive a `LaunchConfig` via TCP from the launcher
-- The config defines which processes to start, in what order, and dependency rules
-- Connect to the launcher on the given port
-- Start wand.exe (or another app defined in the config)
-- Start the game executable and wait
-- On game exit, send a `session_complete` event to the launcher
-- The launcher cleans up and the monitor exits
+- Download `monitor.exe` from the monitor's own GitHub releases (separate repo from both launcher and wand app)
+- Send a structured `LaunchConfig` via TCP/JSON — defines game exe path, wand exe path, start order, dependencies, and shutdown rules
+- Wait for the monitor to respond with `session_complete` containing the game's exit code
+- Return that exit code as the launcher's own exit code
 
-This replaces the old bat file approach. Instead of a hardcoded batch script, the monitor uses a config-driven system where the launcher sends a structured `LaunchConfig` via JSON over TCP. This means the monitor is not limited to wand — it can manage any set of processes with proper lifecycle handling, dependencies, and startup order.
+The monitor replaces the old bat file approach with a config-driven protocol. The launcher only worries about building the config and reading the result — the monitor handles all process lifecycle inside Wine/Proton.

--- a/docs/base-guidelines.md
+++ b/docs/base-guidelines.md
@@ -13,7 +13,7 @@ The main flow is simple — the launcher is essentially a fancy argument parser.
 - **SettingsManager** — basic init: parses `sys.argv` and computes XDG paths. No config files loaded yet.
 - **LogManager** — takes settings (reads log path from it), starts the log file.
 - **Interface** — detected from settings flags: PyQt6 by default, CLI if `--cli` or `--no-prompt`.
-- **Root guard** — checks `os.geteuid()` and `--force-root`, exits early if running as root without the flag.
+- **Root guard** — `check_root(settings, log, interface)`, checks `os.geteuid()` and `--force-root`, exits early if running as root without the flag.
 - **SettingsManager.load_all()** — loads global config (`config.json`), game config (`games.json`), and metadata. Merge priority: CLI args > env vars > game config > global config > hardcoded defaults.
 - Enter the main execution block
 

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -1,0 +1,59 @@
+# Project Goals & Direction
+
+## Codebase & Architecture
+
+- Structured, readable code with clear separation of concerns
+- Group code by responsibility (paths, settings, logging, UI, steps)
+- Clear internal APIs between components
+- Python is the practical choice — already in use, performance isn't critical at startup
+
+## CLI / Interface Modes
+
+- Full non-interactive mode via CLI flags (`--cli`, `--no-prompt`)
+- Unified interface layer — CLI (print/input) or GUI (PyQt6)
+- Centralized user interaction instead of scattered prompts
+
+## Build & Distribution
+
+- PyInstaller-based build, packaged as AppImage
+- Inside-Wine monitor is a standalone `.exe`, built via CI
+- All libraries bundled — no sandbox escape issues, no venv needed
+- Binary releases instead of source-only
+
+## Process Monitor
+
+- Config-driven process supervisor (declarative, not hardcoded)
+- Multiple process lifecycle management (game + trainer)
+- Event-driven model with structured IPC (TCP/JSON)
+- Clean integration between Wine/Proton and the Linux host
+- Extensible — not limited to a single tool
+
+## Updates & Versioning
+
+- Proper binary updater via GitHub Releases
+- Structured migration system for breaking changes (config layout, data format)
+- GitHub Actions: builds, metadata, tests, formatting
+
+## Configuration & Environment
+
+- Tiered config: CLI args → env vars → config file → defaults
+- Consistent prefix handling between Proton and Wine (`pfx` normalization, symlinks)
+- XDG-compliant paths everywhere
+
+## Logging & Debugging
+
+- Subscription/event-based logging — components emit structured events
+- Standard log levels, optional event stream subscriptions
+- Multiple handlers (console, file, UI) that process events differently
+- Structured, contextual messages for debugging
+
+## Path & Filesystem
+
+- Dedicated path management with Unix ↔ Wine conversion utilities
+- Symlink resolution, ownership handling, cache management
+- Centralized, predictable filesystem operations
+
+## Platform
+
+- Container-compatible via AppImage
+- "Wand launcher" — multi-tool, not tied to a single provider

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -138,12 +138,12 @@ Settings are exposed as flat attributes (`settings.is_cli`, `settings.download_u
 
 ### Step Runner (After Bootstrap)
 
-After bootstrap, a `StepRunner` is created with three core objects (settings, interface, log). Every action phase goes through the runner, which wraps `step()` or `step_code()`:
+After bootstrap, a `StepRunner` is created with the three core objects (settings, interface, log). Every action phase goes through the runner, which wraps `step()` or `step_code()`:
 
 - `step()` — catches exceptions, calls `interface.error_msg_and_log(type, msg)`, returns True on failure
 - `step_code()` — same but returns `(failed, code)` for phases that produce an exit code
 
-Boolean flags (s, i, lg) control which core objects get passed to the phase function. Phase functions receive `(settings, interface, log)` by default and access paths through the settings object. This keeps calls concise and makes the parameter contract explicit at the call site.
+All three objects are always passed — every phase receives `(settings, interface, log)` consistently. Phase functions access paths through the settings object and may show messages or progress via the interface.
 
 ---
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -13,11 +13,9 @@ Relative to `src/wand_launcher/`:
 ./__main__.py                  # python -m wand_launcher → launcher.main()
 ./launcher.py                  # bootstrap → _run_flow() → troubleshooter
 ./core/__init__.py
-./core/args.py                 # ArgManager (sys.argv wrapper)
 ./core/guards.py               # step(), step_code(), check_root
-./core/paths.py                # PathManager (XDG paths)
 ./core/runner.py               # StepRunner (step/step_code convenience)
-./core/settings.py             # SettingsManager (tiered config merge)
+./core/settings.py             # SettingsManager (args + paths + config merge)
 ./logging/__init__.py
 ./logging/event_bus.py         # LogManager with typed emit/subscribe
 ./logging/handlers.py          # File, console, UI log handlers
@@ -60,61 +58,53 @@ Relative to `src/wand_launcher/`:
 
 ## Bootstrap Sequence
 
-### PathManager
+The bootstrap follows this order:
 
-The first object created. It computes XDG paths once:
+1. **SettingsManager** — basic init (arg parsing + base paths)
+2. **LogManager** — takes settings (reads log path from it)
+3. **Interface** — detected from settings
+4. **Root guard** — uses settings + interface
+5. **SettingsManager.load_all()** — config files, env vars, metadata
+6. **StepRunner** — wraps the three remaining objects (settings, interface, log)
 
-- `~/.local/share/wand/` — persistent data (app binary, prefixes, login data, metadata)
-- `~/.config/wand/` — user and auto-generated config files
-- `~/.cache/wand/` — downloads, temp files, logs
+### SettingsManager (First — Basic Init)
 
-No filesystem operations beyond checking if directories exist. Paths are strings, not `pathlib` objects — the manager centralizes all path logic so callers never construct paths themselves.
+The first object created. On init it handles two things that were previously separate modules:
 
-### LogManager
-
-Created with a reference to PathManager so it knows where to write log files. Implements a typed event bus:
-
-- `log.info(type, message)` → shorthand for `log.emit(type, "info", message)`
-- `log.error(type, message)` → shorthand for `log.emit(type, "error", message)`
-- `log.emit(type, level, message)` → full form, used for custom levels
-
-Events are emitted to all subscribed handlers. By default there's a file handler (writes to `~/.cache/wand/launcher.log`) and a console handler. The interface can subscribe its own handler to display events in the UI. The log file header records the launcher version, Python version, platform, and invocation timestamp.
-
-Subscribers can filter by type (e.g. only `launcher.flow.*`), level, or both. The troubleshooter subscribes to error-level events from the flow namespace to pre-populate its issue report.
-
-### ArgManager
-
-Wraps `sys.argv` once, early in bootstrap. Currently exposes a small set of flags:
+**Arg parsing:** Wraps `sys.argv` once. Currently exposes a small set of flags:
 
 - `is_force_root_active` — whether `--force-root` was passed
 - `is_cli` — whether `--cli` was passed
 - `is_no_prompt` — whether `--no-prompt` was passed
 - `has_post_update` — whether the launcher was re-invoked after a self-update
-- Any remaining positional args (used for game exe path, prefix path, etc.)
+- Positional args (game exe path, prefix path, etc.)
 
 Most flags are not yet finalised — future args will be added as settings require them. `--help` support is an optional goal still under evaluation.
 
-ArgManager only parses CLI flags. It does not merge with config files or env vars — that's SettingsManager's job.
+**Path computation:** Computes XDG paths:
 
-### SettingsManager
+- `settings.data_dir` → `~/.local/share/wand/`
+- `settings.config_dir` → `~/.config/wand/`
+- `settings.cache_dir` → `~/.cache/wand/`
+- Derived paths: `log_path`, `bin_dir`, `login_dir`, `metadata_path`, `prefixes_db_path`
 
-The unified settings layer. Construction order matters:
+Paths are strings, not `pathlib` objects. No filesystem operations happen at init.
 
-1. `SettingsManager(args)` — init from ArgManager only (CLI flags parsed but config not loaded yet)
-2. Later, `settings.load_config()` — merges env vars, config files, and game-specific config
+SettingsManager does **not** load config files yet — that happens after the root guard. The basic init provides just enough (args + base paths) for LogManager and interface detection to function.
 
-Merge priority (highest wins):
-CLI args > env vars > game config > global config > hardcoded defaults.
+### LogManager (Second)
 
-**Global config** lives at `~/.config/wand/config.json` — user-editable, contains general launcher settings.
+Created with a reference to **settings** (not a separate PathManager). Reads `settings.log_path` (`~/.cache/wand/launcher.log`) and writes the file header there. Implements a typed event bus:
 
-**Game config** lives at `~/.config/wand/games.json` — maps game paths (used as IDs) to per-game overrides. A game may have no entry at all, partial settings, or full overrides.
+- `log.info(type, message)` → shorthand for `log.emit(type, "info", message)`
+- `log.error(type, message)` → shorthand for `log.emit(type, "error", message)`
+- `log.emit(type, level, message)` → full form, used for custom levels
 
-**Auto-generated metadata** is stored in `~/.local/share/wand/metadata.json` (version, URLs, download links, user agent, etc.). Some of these values are exposed through SettingsManager but are read-only — they can only be changed via the manifest file and are not meant to be edited by users. The settings layer enforces which keys are overridable and which are manifest-only.
+Events are emitted to all subscribed handlers. By default there's a file handler (writes to the log path) and a console handler. The interface can subscribe its own handler to display events in the UI. The log file header records the launcher version, Python version, platform, and invocation timestamp.
 
-Settings are exposed as flat attributes (`settings.is_cli`, `settings.download_url`, etc.) — no nested dict access.
+Subscribers can filter by type (e.g. only `launcher.flow.*`), level, or both. The troubleshooter subscribes to error-level events from the flow namespace to pre-populate its issue report.
 
-### Interface Detection
+### Interface Detection (Third)
 
 `detect_interface(settings, log)` returns either a `GUIInterface` (PyQt6) or `CLIInterface` instance. The decision:
 
@@ -129,18 +119,31 @@ The interface protocol currently includes:
 - `error_msg_and_log(type, text)` — log the type and text, then show the text
 - Additional methods for progress, prompts, etc. (defined in the abstract base)
 
-### Root Guard
+### Root Guard (Fourth)
 
-`check_root(interface, settings)` runs before `settings.load_config()`. If `os.geteuid() == 0` and `settings.is_force_root_active` is False, it shows a message and calls `sys.exit(1)`. The interface is passed so the message is visible in both GUI and CLI mode. Config files are not loaded until after this check passes — no point reading config if we're about to exit.
+`check_root(interface, settings)` runs before `settings.load_all()`. If `os.geteuid() == 0` and `settings.is_force_root_active` is False, it shows a message and calls `sys.exit(1)`. The interface is passed so the message is visible in both GUI and CLI mode. Config files are not loaded until after this check passes — no point reading config if we're about to exit.
 
-### Step Runner
+### SettingsManager.load_all() (Fifth)
 
-After bootstrap, a `StepRunner` is created with the four core objects (path_mgr, settings, interface, log). Every action phase goes through the runner, which wraps `step()` or `step_code()`:
+After the root guard passes, the full settings stack is loaded:
+
+1. **Global config** — `~/.config/wand/config.json`, user-editable, general launcher settings
+2. **Game config** — `~/.config/wand/games.json`, maps game paths (as IDs) to per-game overrides. A game may have no entry at all, partial settings, or full overrides.
+3. **Metadata** — `~/.local/share/wand/metadata.json`, auto-generated (version, URLs, download links, user agent, etc.)
+
+Merge priority (highest wins):
+CLI args > env vars > game config > global config > hardcoded defaults.
+
+Settings are exposed as flat attributes (`settings.is_cli`, `settings.download_url`, etc.) — no nested dict access. Metadata values are available through settings but are read-only — they can only be changed via the manifest and are not meant to be user-edited.
+
+### Step Runner (After Bootstrap)
+
+After bootstrap, a `StepRunner` is created with three core objects (settings, interface, log). Every action phase goes through the runner, which wraps `step()` or `step_code()`:
 
 - `step()` — catches exceptions, calls `interface.error_msg_and_log(type, msg)`, returns True on failure
 - `step_code()` — same but returns `(failed, code)` for phases that produce an exit code
 
-Boolean flags (p, s, i, lg) control which core objects get passed to the phase function. This keeps calls concise and makes the parameter contract explicit at the call site.
+Boolean flags (s, i, lg) control which core objects get passed to the phase function. Phase functions receive `(settings, interface, log)` by default and access paths through the settings object. This keeps calls concise and makes the parameter contract explicit at the call site.
 
 ---
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -4,6 +4,58 @@
 
 The launcher is a sequential pipeline: bootstrap core services, run action phases, show the troubleshooter if anything failed. Every phase is wrapped in a guard that catches exceptions, logs them with type and message, and shows a user-facing error notification. Non-fatal errors in one phase don't stop later phases from running.
 
+## Initial File Structure
+
+Relative to `src/wand_launcher/`:
+
+```
+./__init__.py
+./__main__.py                  # python -m wand_launcher → launcher.main()
+./launcher.py                  # bootstrap → _run_flow() → troubleshooter
+./core/__init__.py
+./core/args.py                 # ArgManager (sys.argv wrapper)
+./core/guards.py               # step(), step_code(), check_root
+./core/paths.py                # PathManager (XDG paths)
+./core/runner.py               # StepRunner (step/step_code convenience)
+./core/settings.py             # SettingsManager (tiered config merge)
+./logging/__init__.py
+./logging/event_bus.py         # LogManager with typed emit/subscribe
+./logging/handlers.py          # File, console, UI log handlers
+./migrations/__init__.py       # apply_migrations
+./migrations/...               # individual migration scripts
+./monitor/__init__.py          # launch_monitor
+./monitor/protocol.py          # LaunchConfig schema, session_complete
+./monitor/ipc/__init__.py
+./prefixes/__init__.py
+./prefixes/manager.py          # setup_prefix (orchestrator)
+./prefixes/scanner.py          # scan sibling prefixes
+./prefixes/matcher.py          # best-match logic
+./prefixes/builder.py          # winetricks-based build
+./prefixes/downloader.py       # download pre-built prefix
+./troubleshooter/__init__.py   # run_troubleshooter
+./troubleshooter/...           # GUI/CLI variants
+./ui/__init__.py
+./ui/detect.py                 # detect_interface
+./ui/base.py                   # abstract Interface protocol
+./ui/cli.py                    # CLIInterface
+./ui/gui/__init__.py
+./ui/gui/app.py
+./ui/gui/main_window.py
+./ui/gui/dialogs.py
+./ui/gui/progress.py
+./updates/__init__.py          # update_if_needed
+./updates/binary.py            # AppImage/production updater
+./updates/dev.py               # git-pull source updater
+./utils/__init__.py
+./utils/download.py            # unified download service
+./utils/path_utils.py          # Unix↔Wine path conversion, symlink resolution
+./wand/__init__.py
+./wand/installer.py            # ensure_app (download & verify archive)
+./wand/data_sync.py            # sync_app_data (login/ dir symlink)
+```
+
+> This is the initial file structure and is subject to change based on project needs and scope.
+
 ---
 
 ## Bootstrap Sequence
@@ -32,13 +84,15 @@ Subscribers can filter by type (e.g. only `launcher.flow.*`), level, or both. Th
 
 ### ArgManager
 
-Wraps `sys.argv` once, early in bootstrap. Exposes parsed flags as attributes:
+Wraps `sys.argv` once, early in bootstrap. Currently exposes a small set of flags:
 
 - `is_force_root_active` — whether `--force-root` was passed
 - `is_cli` — whether `--cli` was passed
 - `is_no_prompt` — whether `--no-prompt` was passed
 - `has_post_update` — whether the launcher was re-invoked after a self-update
 - Any remaining positional args (used for game exe path, prefix path, etc.)
+
+Most flags are not yet finalised — future args will be added as settings require them. `--help` support is an optional goal still under evaluation.
 
 ArgManager only parses CLI flags. It does not merge with config files or env vars — that's SettingsManager's job.
 
@@ -47,11 +101,18 @@ ArgManager only parses CLI flags. It does not merge with config files or env var
 The unified settings layer. Construction order matters:
 
 1. `SettingsManager(args)` — init from ArgManager only (CLI flags parsed but config not loaded yet)
-2. Later, `settings.load_config()` — merges env vars and config files
+2. Later, `settings.load_config()` — merges env vars, config files, and game-specific config
 
-Merge priority (highest wins): CLI args > env vars > config files > hardcoded defaults.
+Merge priority (highest wins):
+CLI args > env vars > game config > global config > hardcoded defaults.
 
-Config files are loaded from `~/.config/wand/`. The user-editable file is `config.json`. Auto-generated metadata is stored in `~/.local/share/wand/metadata.json` (version, URLs, download links, etc.). Settings are exposed as flat attributes (`settings.is_cli`, `settings.download_url`, etc.) — no nested dict access.
+**Global config** lives at `~/.config/wand/config.json` — user-editable, contains general launcher settings.
+
+**Game config** lives at `~/.config/wand/games.json` — maps game paths (used as IDs) to per-game overrides. A game may have no entry at all, partial settings, or full overrides.
+
+**Auto-generated metadata** is stored in `~/.local/share/wand/metadata.json` (version, URLs, download links, user agent, etc.). Some of these values are exposed through SettingsManager but are read-only — they can only be changed via the manifest file and are not meant to be edited by users. The settings layer enforces which keys are overridable and which are manifest-only.
+
+Settings are exposed as flat attributes (`settings.is_cli`, `settings.download_url`, etc.) — no nested dict access.
 
 ### Interface Detection
 
@@ -60,7 +121,9 @@ Config files are loaded from `~/.config/wand/`. The user-editable file is `confi
 - If `--cli` or `--no-prompt` flags are set → CLIInterface
 - Otherwise → GUIInterface (default)
 
-The interface implements a small protocol:
+The abstraction auto-routes to the correct implementation. Each interface lives in its own file and implements a shared protocol. More interface types may be added later.
+
+The interface protocol currently includes:
 
 - `show_message(text)` — display a message to the user (modal dialog or print)
 - `error_msg_and_log(type, text)` — log the type and text, then show the text
@@ -94,10 +157,10 @@ Checks for and applies launcher self-updates. Two modes:
 - A post-update marker is set so the re-invoked launcher knows an update just happened
 - The swap is atomic: download to temp, rename over old, then re-exec
 
-**Dev mode:**
-- Runs `git pull` in the repository directory
+**Run from source mode:**
+- Detected by running from a git repository (no AppImage, no binary release)
+- Runs `git pull` in the repository directory — only makes sense in a git context
 - Does not reset --hard — preserves local changes
-- Only triggers if the running version is a dev build (detected via version string or presence of `.git`)
 
 If the network is unreachable, the updater logs the error and continues silently — a failed update is not a fatal error.
 
@@ -120,10 +183,12 @@ After all migrations succeed, `metadata.json` is updated with the current schema
 
 Ensures the app exe exists at `~/.local/share/wand/bin/`. The logic:
 
-1. Check if the exe is already present and the checksum matches
-2. If missing or corrupted, download from the URL in `metadata.json`
-3. Extract the archive to `~/.cache/wand/` then copy the exe to `~/.local/share/wand/bin/`
-4. Verify the checksum of the extracted file
+1. Check if the exe is already present
+2. If missing, download the archive from the URL in `metadata.json`
+3. Verify the downloaded archive against its reported checksum (the checksum is provided by the online repo alongside the download link)
+4. Extract to `~/.cache/wand/` then copy the exe to `~/.local/share/wand/bin/`
+
+Checksum verification is done on the archive, not the extracted file — the online repo provides the archive checksum alongside the download link. Verifying the extracted binary would require pre-generating checksums for every version, storing them in the manifest, and keeping them in sync — it's simpler and sufficient to just verify the archive.
 
 Downloads use the unified download service (see Utilities section). The app exe is shared across all prefixes — it's installed once and every prefix uses the same binary.
 
@@ -178,23 +243,18 @@ Copy the app data folder from inside the prefix to `~/.local/share/wand/login/`.
 **Step 3: Symlink back**
 Remove the app data folder inside the prefix and replace it with a symlink pointing to `~/.local/share/wand/login/`. Now all games that use this launcher share the same app data — logins, settings, and cached data are synchronized by design.
 
-If the shared data already has files (from a previous run or another game), the sync preserves them — only new or changed files are copied.
+If both the prefix app data and the shared `login/` directory already have content (e.g. from a previous game), the launcher prompts the user to resolve the conflict: use the current game account (overwrites the shared store), use the existing shared data (overwrites the prefix copy), or exit.
 
 ### Monitor Launch
 
-The last action phase. Replaces the game command with the monitor process.
+The last action phase. From the launcher's perspective:
 
-The monitor is a separate binary that lives inside the Wine prefix (or is downloaded alongside the app). Its job is process lifecycle management:
+1. Download the monitor binary from the monitor's own GitHub releases (separate repo from both the launcher and the wand app)
+2. Send a `LaunchConfig` via TCP/JSON containing the game exe path, wand exe path, and lifecycle instructions (start order, dependencies, shutdown rules)
+3. Wait for the monitor to report `session_complete` with the game's exit code
+4. Return that exit code as the launcher's own exit code
 
-1. Receive a `LaunchConfig` via TCP/JSON from the launcher
-2. Start the app executable (wand.exe)
-3. Start the game executable
-4. Wait for the game to exit
-5. If wand is still running after the game exits, send a terminate signal
-6. Send a `session_complete` event to the launcher with the game's exit code
-7. Exit
-
-The launcher waits for the monitor's exit code and returns it as its own exit code. If the monitor cannot be started (missing binary, port in use, etc.), the phase reports failure and the troubleshooter runs.
+The monitor is a separate binary and lives in its own repository — this section only covers the launcher side of the interaction. If the monitor cannot be started (missing binary, port in use, etc.), the phase reports failure and the troubleshooter runs.
 
 ---
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -65,7 +65,7 @@ The bootstrap follows this order:
 3. **Interface** — detected from settings
 4. **Root guard** — uses settings + interface
 5. **SettingsManager.load_all()** — config files, env vars, metadata
-6. **StepRunner** — wraps the three remaining objects (settings, interface, log)
+6. **StepRunner** — wraps the three remaining objects (settings, log, interface)
 
 ### SettingsManager (First — Basic Init)
 
@@ -96,6 +96,8 @@ SettingsManager does **not** load config files yet — that happens after the ro
 
 Created with a reference to **settings** (not a separate PathManager). Reads `settings.log_path` (`~/.cache/wand/launcher.log`) and writes the file header there. Implements a typed event bus:
 
+> This is a placeholder implementation. The final version may use Python's built-in `logging` module if that makes more sense. Log output should include timestamps and structured type/level fields.
+
 - `log.info(type, message)` → shorthand for `log.emit(type, "info", message)`
 - `log.error(type, message)` → shorthand for `log.emit(type, "error", message)`
 - `log.emit(type, level, message)` → full form, used for custom levels
@@ -121,7 +123,7 @@ The interface protocol currently includes:
 
 ### Root Guard (Fourth)
 
-`check_root(interface, settings)` runs before `settings.load_all()`. If `os.geteuid() == 0` and `settings.is_force_root_active` is False, it shows a message and calls `sys.exit(1)`. The interface is passed so the message is visible in both GUI and CLI mode. Config files are not loaded until after this check passes — no point reading config if we're about to exit.
+`check_root(settings, log, interface)` runs before `settings.load_all()`. If `os.geteuid() == 0` and `settings.is_force_root_active` is False, it shows a message and calls `sys.exit(1)`. Config files are not loaded until after this check passes — no point reading config if we're about to exit.
 
 ### SettingsManager.load_all() (Fifth)
 
@@ -138,12 +140,12 @@ Settings are exposed as flat attributes (`settings.is_cli`, `settings.download_u
 
 ### Step Runner (After Bootstrap)
 
-After bootstrap, a `StepRunner` is created with the three core objects (settings, interface, log). Every action phase goes through the runner, which wraps `step()` or `step_code()`:
+After bootstrap, a `StepRunner` is created with the three core objects (settings, log, interface). Every action phase goes through the runner, which wraps `step()` or `step_code()`:
 
 - `step()` — catches exceptions, calls `interface.error_msg_and_log(type, msg)`, returns True on failure
 - `step_code()` — same but returns `(failed, code)` for phases that produce an exit code
 
-All three objects are always passed — every phase receives `(settings, interface, log)` consistently. Phase functions access paths through the settings object and may show messages or progress via the interface.
+All three objects are always passed — every phase receives `(settings, log, interface)` consistently, matching the bootstrap creation order. Phase functions access paths through settings, emit events through log, and show messages or progress via the interface.
 
 ---
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -1,0 +1,234 @@
+# Implementation Guide
+
+## Overview
+
+The launcher is a sequential pipeline: bootstrap core services, run action phases, show the troubleshooter if anything failed. Every phase is wrapped in a guard that catches exceptions, logs them with type and message, and shows a user-facing error notification. Non-fatal errors in one phase don't stop later phases from running.
+
+---
+
+## Bootstrap Sequence
+
+### PathManager
+
+The first object created. It computes XDG paths once:
+
+- `~/.local/share/wand/` — persistent data (app binary, prefixes, login data, metadata)
+- `~/.config/wand/` — user and auto-generated config files
+- `~/.cache/wand/` — downloads, temp files, logs
+
+No filesystem operations beyond checking if directories exist. Paths are strings, not `pathlib` objects — the manager centralizes all path logic so callers never construct paths themselves.
+
+### LogManager
+
+Created with a reference to PathManager so it knows where to write log files. Implements a typed event bus:
+
+- `log.info(type, message)` → shorthand for `log.emit(type, "info", message)`
+- `log.error(type, message)` → shorthand for `log.emit(type, "error", message)`
+- `log.emit(type, level, message)` → full form, used for custom levels
+
+Events are emitted to all subscribed handlers. By default there's a file handler (writes to `~/.cache/wand/launcher.log`) and a console handler. The interface can subscribe its own handler to display events in the UI. The log file header records the launcher version, Python version, platform, and invocation timestamp.
+
+Subscribers can filter by type (e.g. only `launcher.flow.*`), level, or both. The troubleshooter subscribes to error-level events from the flow namespace to pre-populate its issue report.
+
+### ArgManager
+
+Wraps `sys.argv` once, early in bootstrap. Exposes parsed flags as attributes:
+
+- `is_force_root_active` — whether `--force-root` was passed
+- `is_cli` — whether `--cli` was passed
+- `is_no_prompt` — whether `--no-prompt` was passed
+- `has_post_update` — whether the launcher was re-invoked after a self-update
+- Any remaining positional args (used for game exe path, prefix path, etc.)
+
+ArgManager only parses CLI flags. It does not merge with config files or env vars — that's SettingsManager's job.
+
+### SettingsManager
+
+The unified settings layer. Construction order matters:
+
+1. `SettingsManager(args)` — init from ArgManager only (CLI flags parsed but config not loaded yet)
+2. Later, `settings.load_config()` — merges env vars and config files
+
+Merge priority (highest wins): CLI args > env vars > config files > hardcoded defaults.
+
+Config files are loaded from `~/.config/wand/`. The user-editable file is `config.json`. Auto-generated metadata is stored in `~/.local/share/wand/metadata.json` (version, URLs, download links, etc.). Settings are exposed as flat attributes (`settings.is_cli`, `settings.download_url`, etc.) — no nested dict access.
+
+### Interface Detection
+
+`detect_interface(settings, log)` returns either a `GUIInterface` (PyQt6) or `CLIInterface` instance. The decision:
+
+- If `--cli` or `--no-prompt` flags are set → CLIInterface
+- Otherwise → GUIInterface (default)
+
+The interface implements a small protocol:
+
+- `show_message(text)` — display a message to the user (modal dialog or print)
+- `error_msg_and_log(type, text)` — log the type and text, then show the text
+- Additional methods for progress, prompts, etc. (defined in the abstract base)
+
+### Root Guard
+
+`check_root(interface, settings)` runs before `settings.load_config()`. If `os.geteuid() == 0` and `settings.is_force_root_active` is False, it shows a message and calls `sys.exit(1)`. The interface is passed so the message is visible in both GUI and CLI mode. Config files are not loaded until after this check passes — no point reading config if we're about to exit.
+
+### Step Runner
+
+After bootstrap, a `StepRunner` is created with the four core objects (path_mgr, settings, interface, log). Every action phase goes through the runner, which wraps `step()` or `step_code()`:
+
+- `step()` — catches exceptions, calls `interface.error_msg_and_log(type, msg)`, returns True on failure
+- `step_code()` — same but returns `(failed, code)` for phases that produce an exit code
+
+Boolean flags (p, s, i, lg) control which core objects get passed to the phase function. This keeps calls concise and makes the parameter contract explicit at the call site.
+
+---
+
+## Action Phases
+
+### Updater
+
+Checks for and applies launcher self-updates. Two modes:
+
+**Production (AppImage):**
+- Fetches the latest release metadata from GitHub Releases API
+- Compares the published version against the running version (embedded in the AppImage metadata)
+- If a newer version exists, downloads the AppImage to `~/.cache/wand/` and swaps it with the current binary
+- A post-update marker is set so the re-invoked launcher knows an update just happened
+- The swap is atomic: download to temp, rename over old, then re-exec
+
+**Dev mode:**
+- Runs `git pull` in the repository directory
+- Does not reset --hard — preserves local changes
+- Only triggers if the running version is a dev build (detected via version string or presence of `.git`)
+
+If the network is unreachable, the updater logs the error and continues silently — a failed update is not a fatal error.
+
+### Migrations
+
+Checks `~/.local/share/wand/metadata.json` for a stored schema version and compares it against the expected version bundled with the launcher. If they differ, pending migrations run in order.
+
+Each migration is a function that receives `settings` and `log`. Migrations can:
+
+- Move or restructure files and directories (e.g., old config layout → new XDG layout)
+- Update config file formats (e.g., ini → JSON)
+- Transform the prefix database schema
+- Delete deprecated cache files
+
+Migrations are idempotent where possible. If a migration fails, the error is logged and the phase reports failure — the launcher cannot safely continue with an unknown schema version.
+
+After all migrations succeed, `metadata.json` is updated with the current schema version. The file also stores the launcher version, download URLs, user agent string, and other auto-generated config.
+
+### App Install
+
+Ensures the app exe exists at `~/.local/share/wand/bin/`. The logic:
+
+1. Check if the exe is already present and the checksum matches
+2. If missing or corrupted, download from the URL in `metadata.json`
+3. Extract the archive to `~/.cache/wand/` then copy the exe to `~/.local/share/wand/bin/`
+4. Verify the checksum of the extracted file
+
+Downloads use the unified download service (see Utilities section). The app exe is shared across all prefixes — it's installed once and every prefix uses the same binary.
+
+### Prefix Setup
+
+The most complex phase. Goal: ensure the Wine prefix has the app installed and ready.
+
+**Step 1: Normalize the prefix**
+- If a `pfx/` subdirectory exists, move all files and folders up one level, delete the empty `pfx/`, and create a symlink `pfx → .`
+- If `drive_c/users/steamuser/` exists, move contents to `drive_c/users/$USER/`, delete `steamuser`, and create a symlink `steamuser → $USER`
+- These normalizations handle the difference between Steam Proton prefixes (which use `pfx/` and `steamuser`) and standalone Wine prefixes
+
+**Step 2: Check for existing installation**
+- Look for `.wand_installer` marker in the same folder as `drive_c`
+- If found, the prefix is ready — skip to data sync
+
+**Step 3: Scan sibling prefixes**
+Walk the parent directory looking for other prefixes that have `.wand_installer`. For each found prefix, record:
+
+- Path
+- App version installed
+- Wine version used
+- OS architecture (win32/win64)
+- Any additional components installed
+
+Results are cached in `~/.local/share/wand/prefixes.json`. Stale entries (prefix directories that no longer exist) are removed on each scan.
+
+**Step 4: Match or build**
+
+Present options to the user (varies based on how many valid prefixes were found):
+
+- **Closest match** — copy the best-matching sibling prefix. Matching considers app version (exact match preferred), Wine version, and architecture.
+- **Second closest** — auto-pick the next best if exactly 2 valid prefixes exist (skips the prompt)
+- **Download** — fetch a pre-built prefix from GitHub Releases, extract to `~/.cache/wand/`, then move into place
+- **List all** — let the user pick from all valid prefixes (shown when 3+ exist)
+- **Build** — download winetricks, run: `winetricks -q sdl cjkfonts vkd3d dxvk2030 dotnet48`, then write `.wand_installer` next to `system.reg`
+- **Exit** — cancel the whole flow
+
+**Step 5: Post-setup**
+After the prefix is ready (copied, downloaded, or built), the `.wand_installer` marker is written if not already present. The prefix path is stored for the data sync and monitor phases.
+
+### Data Sync
+
+After the prefix is ready, app data needs to be shared across all games.
+
+**Step 1: Create the shared data directory**
+`~/.local/share/wand/login/` — this is the central app data store. If it doesn't exist, create an empty one.
+
+**Step 2: Sync prefix data to shared storage**
+Copy the app data folder from inside the prefix to `~/.local/share/wand/login/`. This is a one-time copy — subsequent runs use the existing shared data.
+
+**Step 3: Symlink back**
+Remove the app data folder inside the prefix and replace it with a symlink pointing to `~/.local/share/wand/login/`. Now all games that use this launcher share the same app data — logins, settings, and cached data are synchronized by design.
+
+If the shared data already has files (from a previous run or another game), the sync preserves them — only new or changed files are copied.
+
+### Monitor Launch
+
+The last action phase. Replaces the game command with the monitor process.
+
+The monitor is a separate binary that lives inside the Wine prefix (or is downloaded alongside the app). Its job is process lifecycle management:
+
+1. Receive a `LaunchConfig` via TCP/JSON from the launcher
+2. Start the app executable (wand.exe)
+3. Start the game executable
+4. Wait for the game to exit
+5. If wand is still running after the game exits, send a terminate signal
+6. Send a `session_complete` event to the launcher with the game's exit code
+7. Exit
+
+The launcher waits for the monitor's exit code and returns it as its own exit code. If the monitor cannot be started (missing binary, port in use, etc.), the phase reports failure and the troubleshooter runs.
+
+---
+
+## Troubleshooter
+
+Always runs, regardless of whether the flow succeeded. Two modes:
+
+**GUI (default):** PyQt6 window with tabs:
+- Status overview (which phases passed/failed)
+- Log viewer (filterable, searchable)
+- Action buttons: retry prefix setup, redownload app, delete prefix and start fresh
+- Report generation (copies recent logs and system info to clipboard)
+
+**CLI:** Text-based prompts with the same options. Progress bars use line-overwrite (carriage return) for clean output. The troubleshooter can be skipped entirely with `--no-prompt` — in that mode it only logs and exits.
+
+The troubleshooter subscribes to error-level log events during the flow run, so by the time it opens it already knows what went wrong.
+
+---
+
+## Utilities
+
+### Download Service
+
+Unified download function used by the updater, app installer, and prefix downloader:
+
+- User-Agent rotation for GitHub API calls
+- Automatic retry with exponential backoff (3 retries, 2s base delay)
+- Progress reporting via optional callback
+- Checksum verification after download (SHA-256)
+- Resume support for large downloads (range requests)
+- Cache management: downloads go to `~/.cache/wand/`, cleaned up after extraction
+
+### Path Utilities
+
+- **Unix ↔ Wine path conversion:** `/home/user/.wine/drive_c/...` ↔ `C:\...`
+- **Symlink resolution:** resolve real paths through symlink chains
+- **Prefix normalization:** detect and fix `pfx/` and `steamuser` layouts


### PR DESCRIPTION
docs/base-guidelines.md — launcher flow overview (moved from src/wand_launcher/Docs.md and renamed).
docs/goals.md — project goals and direction (rewritten). docs/implementation.md — detailed implementation guide covering each phase's internal logic, no code.

This is not needed but i just made it as an option.