### PR TITLE
refactor: Use `Prek` for pre-commit hooks and enforce in CI

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -3,34 +3,16 @@ name: Run linter on codebase and commits in PRs
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - rewrite/v2 # FIXME: To be changed to `main` once we release V2.
     types:
       - opened
       - edited
       - synchronize
-  
+
 jobs:
-  check-codebase:
+  run-prek-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/ruff-action@v3
-  check-codebase-formatting:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: astral-sh/ruff-action@v3
-        with:
-          args: "format --check --diff"
-  check-commit-msg:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: agenthunt/conventional-commit-checker-action@v2.0.1
+      - uses: j178/prek-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: "v6.0.0"
+    hooks:
+      - id: check-added-large-files
+  - repo: builtin
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.15.17"
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: "v0.0.50"
+    hooks:
+      - id: ty
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: "v4.4.0"
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: []

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,4 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "wand-launcher"
-version = "2.0.0"
 source = { editable = "." }


### PR DESCRIPTION
This PR  adds `prek`, a lightweight tool for pre-commit hooks, which should help us enforce standards and proper code when committing to wemod-launcher.

However, it does entail that we should use the CLI, _not_ the web interface, although as the project progresses, we'll move towards everything being merged via PRs, no direct commits.

Depends on: https://github.com/DeckCheatz/wemod-launcher/pull/278