### PR TITLE
feat: Add Dependabot configuration for deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(pip-deps)"
+    groups:
+      pip-deps:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci-deps)"
+    groups:
+      gh-actions-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR adds Dependabot to the project, which will open PRs for updating dependencies in Python and GH Actions.
This line was added because it satisfies the conventional pr checker.