### PR TITLE
fix: tolerate existing central dir in syncwemod

### DIFF
--- a/src/wemod.py
+++ b/src/wemod.py
@@ -404,7 +404,7 @@ def syncwemod(
                 f"Directory '{WeModData}' is empty, but '{WeModExternal}' has data. Moving data from external to central."
             )
             # WeModData already exists (created earlier), so directly copy into it.
-            shutil.copytree(WeModExternal, WeModData)
+            shutil.copytree(WeModExternal, WeModData, dirs_exist_ok=True)
         else:
             # Either WeModExternal has no content, or WeModData already has content and is preferred.
             log(


### PR DESCRIPTION
Was messing around with multiple prefixes and hit this in sync. Central data and prefix data can drift since different games update the WeMod store at different times, so the sync has to handle a copy onto an existing central dir instead of assuming it is missing. 