### PR TITLE
Ship DWriteCore.dll to stop the renderer crashing under Wine

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -386,6 +386,66 @@ def check_flatpak(flatpak_cmd: Optional[List[str]]) -> List[str]:
         return []
 
 
+# NuGet package shipping Microsoft's redistributable DWriteCore.dll.
+DWRITECORE_PACKAGE = "microsoft.windowsappsdk.dwrite"
+DWRITECORE_VERSION = "2.1.0"
+DWRITECORE_MEMBER = "runtimes-framework/win-x64/native/DWriteCore.dll"
+
+
+def ensure_dwritecore(install_location: str) -> None:
+    """Place Microsoft's DWriteCore.dll next to WeMod.exe.
+
+    Wine's builtin dwrite.dll raises EXCEPTION_ACCESS_VIOLATION (0xc0000005)
+    when Chromium asks it to map characters for certain pages. That kills
+    WeMod's renderer process, so panels such as the in-app Map stay blank
+    forever while the rest of the client keeps working.
+
+    Chromium loads a DWriteCore.dll placed next to its executable in
+    preference to the system dwrite.dll, so dropping the redistributable in
+    the WeMod directory avoids Wine's broken implementation entirely. No
+    command line flag is needed.
+    """
+    import tempfile
+    import zipfile
+
+    if str(load_conf_setting("DWriteCore")).lower() in ("false", "0", "no"):
+        log("DWriteCore disabled via config, using Wine's dwrite.dll")
+        return
+
+    target = os.path.join(install_location, "DWriteCore.dll")
+    if os.path.isfile(target) and os.getenv("FORCE_UPDATE_WEMOD", "0") != "1":
+        return
+
+    version = load_conf_setting("DWriteCoreVersion") or DWRITECORE_VERSION
+    url = (
+        f"https://api.nuget.org/v3-flatcontainer/{DWRITECORE_PACKAGE}/"
+        f"{version}/{DWRITECORE_PACKAGE}.{version}.nupkg"
+    )
+
+    log(f"DWriteCore.dll not found, downloading version {version}")
+    temp_dir = tempfile.mkdtemp(prefix="wemod-dwritecore-")
+    package = os.path.join(temp_dir, "dwritecore.nupkg")
+    try:
+        download_progress(url, package, None)
+        with zipfile.ZipFile(package) as archive:
+            with archive.open(DWRITECORE_MEMBER) as src:
+                data = src.read()
+        os.makedirs(install_location, exist_ok=True)
+        # Write to a temporary name first so an interrupted download can
+        # never leave a truncated DLL that Chromium would try to load.
+        partial = target + ".part"
+        with open(partial, "wb") as dst:
+            dst.write(data)
+        os.replace(partial, target)
+        log(f"Installed DWriteCore.dll ({len(data)} bytes) to {target}")
+    except Exception as e:
+        # Not fatal: without it WeMod still runs, the Map panel just crashes
+        # its renderer as before.
+        log(f"Could not install DWriteCore.dll: {e}")
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
 def setup_main() -> None:
     import tempfile
     import FreeSimpleGUI as sg
@@ -431,6 +491,7 @@ def setup_main() -> None:
         temp_dir = tempfile.mkdtemp(prefix="wemod-launcher-")
         setup_file = download_wemod(temp_dir)
         unpacked = unpack_wemod(setup_file, temp_dir, install_location)
+        ensure_dwritecore(install_location)
 
         show_message(
             'Setup completed successfully.\nMake sure the "LAUNCH OPTIONS" of the game say \''

--- a/src/wemod.py
+++ b/src/wemod.py
@@ -46,6 +46,7 @@ from mainutils import (
 # Import from setup
 from setup import (
     check_flatpak,
+    ensure_dwritecore,
     self_update,
     setup_main,
     venv_manager,
@@ -449,6 +450,10 @@ def syncwemod(
         os.path.join(SCRIPT_BASE, "wemod_data", "wemod_bin", "WeMod.exe")
     ):
         setup_main()
+
+    # Installs made before this fix existed still have a WeMod.exe but no
+    # DWriteCore.dll, so check on every launch rather than only at setup.
+    ensure_dwritecore(os.path.join(SCRIPT_BASE, "wemod_data", "wemod_bin"))
 
 
 # Initialize the environment


### PR DESCRIPTION
## Problem

WeMod's in-app **Map** panel never renders under Wine. It stays blank
indefinitely while the rest of the client works normally and the trainer keeps
functioning.

The cause is a crash in Wine's builtin `dwrite.dll`. When Chromium asks it to
map characters for the map page, it raises an access violation and takes the
renderer process down with it:

```
warn:seh:dispatch_exception  --- Exception 0xc0000005.
warn:seh:dispatch_exception  EXCEPTION_ACCESS_VIOLATION (code=c0000005) raised
warn:seh:virtual_unwind      DWrite.dll + 0x2b06f
warn:seh:virtual_unwind      DWrite.dll + 0x2ea71
warn:seh:virtual_unwind      DWrite.dll + 0x65db
warn:seh:virtual_unwind      DWrite.dll + 0xbeb3
warn:seh:virtual_unwind      WeMod.exe  + 0x1ce8266     <- Chromium font stack
```

Because only the renderer dies, nothing surfaces to the user: the browser
process stays alive, the trainer keeps polling, and the panel is simply blank.
The page content itself is fine — all 107 requests for the embedded map load
successfully (2.5 MB, zero failures), so this is purely a rendering-side crash.

## Fix

Chromium prefers a `DWriteCore.dll` sitting next to its own executable over the
system `dwrite.dll`. DWriteCore is Microsoft's standalone, redistributable
DirectWrite implementation, published in the `Microsoft.WindowsAppSDK.DWrite`
NuGet package (5.3 MB download, 3.2 MB DLL).

Installing it into `wemod_data/wemod_bin/` bypasses Wine's implementation
entirely. **No command line flag is required** — verified with
`WINEDEBUG=+loaddll` that Chromium picks the DLL up purely by its presence:

```
loaddll:build_module Loaded L"...\wemod_bin\DWriteCore.dll" ... : native
```

The check runs on every launch rather than only during setup, because existing
installs already have a `WeMod.exe` and would otherwise never receive the DLL.

A failed download is logged but never fatal — the client still starts, the Map
panel just crashes as it does today. `DWriteCore=false` opts out;
`DWriteCoreVersion` pins the package version.

## Testing

Renderer processes counted immediately before and after opening the Map:

| | renderers |
|---|---|
| Before fix | **2 → 0** (renderer killed, panel blank) |
| After fix | **2 → 2** (survives, map renders) |

Reproduced and verified against a Proton 10.0 prefix with WeMod 11.6.0
(Electron 34 / Chromium 132), driving the client to the map route over the
DevTools protocol.

Also confirmed end to end through a normal Steam launch (S.T.A.L.K.E.R. 2,
AppID 1643320): the Map panel loads and renders instead of staying blank.

## Ruled out

None of these made any difference, listed so nobody repeats them:

- `WINEFSYNC=0`, and `WINEFSYNC=0 WINEESYNC=0`
- `--no-sandbox`
- `--disable-gpu`, `--use-angle=swiftshader`
- `--disable-remote-fonts`
- `winetricks corefonts` (20 → 44 fonts), plus adding a colour emoji font
- Proton Experimental 11.0 — the Wine bug is not fixed upstream

## Note

The underlying defect is in Wine, not this launcher; this works around it. Worth
reporting to WineHQ separately.
